### PR TITLE
Update requirements and lint config

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -17,7 +17,7 @@ export default [
         sourceType: 'module',
       },
     },
-    settings: { react: { version: '18.3' } },
+    settings: { react: { version: '18.2' } },
     plugins: {
       react,
       'react-hooks': reactHooks,

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ flake8
 gunicorn
 isort
 Pillow
-psycopg2-binary>=2.9.0,<2.10.0  # Compatible with Python 3.11 and 3.12
+psycopg2-binary  # Compatible with Python 3.11 and 3.12
 pytest
 pytest-django
 pytest-cov


### PR DESCRIPTION
## Summary
- remove pinned version from `psycopg2-binary`
- correct React version in ESLint config

## Testing
- `python -m pytest -k "nothing" -q` *(fails: ModuleNotFoundError: No module named 'django')*